### PR TITLE
There are no RedHat 5 packages available but the CentOS 5 equivalents

### DIFF
--- a/manifests/yum.pp
+++ b/manifests/yum.pp
@@ -11,18 +11,24 @@ class duo_unix::yum {
   $package_state = $::duo_unix::package_version
 
   # Map Amazon Linux to RedHat equivalent releases
+  # Map RedHat 5 to CentOS 5 equivalent releases
   if $::operatingsystem == 'Amazon' {
     $releasever = $::operatingsystemmajrelease ? {
       '2014'  => '6Server',
       default => undef,
     }
+    $os = $::operatingsystem
+  } elsif ( $::operatingsystem == 'RedHat' and $::operatingsystemmajrelease == 5 ) {
+    $os = 'CentOS'
+    $releasever = '$releasever'
   } else {
+    $os = $::operatingsystem
     $releasever = '$releasever'
   }
 
   yumrepo { 'duosecurity':
     descr    => 'Duo Security Repository',
-    baseurl  => "${repo_uri}/${::operatingsystem}/${releasever}/\$basearch",
+    baseurl  => "${repo_uri}/${os}/${releasever}/\$basearch",
     gpgcheck => '1',
     enabled  => '1',
     require  => File['/etc/pki/rpm-gpg/RPM-GPG-KEY-DUO'];


### PR DESCRIPTION
work fine. This patch maps the Yum repository from RedHat 5 to CentOS 5.