### PR TITLE
add support for OracleLinux os type

### DIFF
--- a/manifests/yum.pp
+++ b/manifests/yum.pp
@@ -21,6 +21,9 @@ class duo_unix::yum {
   } elsif ( $::operatingsystem == 'RedHat' and $::operatingsystemmajrelease == 5 ) {
     $os = 'CentOS'
     $releasever = '$releasever'
+  } elsif ( $::operatingsystem == "OracleLinux" ) {
+    $os = 'CentOS'
+    $releasever = '$releasever'
   } else {
     $os = $::operatingsystem
     $releasever = '$releasever'


### PR DESCRIPTION
Without this, OEL7 server hosts end up with `baseurl=http://pkg.duosecurity.com/7Server/$releasever/$basearch` which 404s when requesting repomd.xml.