### PR TITLE
inherit duo_unix class for params in template

### DIFF
--- a/manifests/login.pp
+++ b/manifests/login.pp
@@ -6,7 +6,7 @@
 #
 # Mark Stanislav <mstanislav@duosecurity.com>
 #
-class duo_unix::login {
+class duo_unix::login inherits duo_unix {
 
   file { '/etc/duo/login_duo.conf':
     ensure  => present,

--- a/manifests/pam.pp
+++ b/manifests/pam.pp
@@ -6,7 +6,7 @@
 #
 # Mark Stanislav <mstanislav@duosecurity.com>
 #
-class duo_unix::pam {
+class duo_unix::pam inherits duo_unix {
   $aug_pam_path = "/files${duo_unix::pam_file}"
   $aug_match    = "${aug_pam_path}/*/module[. = '${duo_unix::pam_module}']"
 


### PR DESCRIPTION
Re: https://github.com/duosecurity/puppet-duo_unix/issues/15 - without inheritance (or scoping), template renders without parameters from the main class definition.