### PR TITLE
Make repo management optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,7 +100,11 @@ Configures usage of the http_proxy environment variable. There is not default
 for this setting.
 
 ####`manage_ssh [optional]`
-Configures whether or not to allow the module to manage the SSH service/package. 
+Configures whether or not to allow the module to manage the SSH service/package.
+The default is *true*.
+
+####`manage_repo [optional]`
+Configures whether or not to allow the module to add/manage the apt/yum repository.
 The default is *true*.
 
 ####`pam_unix_control [optional]`

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -20,6 +20,7 @@ class duo_unix (
   $prompts = '3',
   $accept_env_factor = 'no',
   $manage_ssh = true,
+  $manage_repo = true,
   $pam_unix_control = 'requisite',
   $package_version = 'installed',
 ) {

--- a/manifests/yum.pp
+++ b/manifests/yum.pp
@@ -26,12 +26,15 @@ class duo_unix::yum {
     $releasever = '$releasever'
   }
 
-  yumrepo { 'duosecurity':
-    descr    => 'Duo Security Repository',
-    baseurl  => "${repo_uri}/${os}/${releasever}/\$basearch",
-    gpgcheck => '1',
-    enabled  => '1',
-    require  => File['/etc/pki/rpm-gpg/RPM-GPG-KEY-DUO'];
+  if $duo_unix::manage_repo {
+    yumrepo { 'duosecurity':
+      descr    => 'Duo Security Repository',
+      baseurl  => "${repo_uri}/${os}/${releasever}/\$basearch",
+      gpgcheck => '1',
+      enabled  => '1',
+      require  => File['/etc/pki/rpm-gpg/RPM-GPG-KEY-DUO'],
+      before   => Package[$duo_unix::duo_package];
+    }
   }
 
   if $duo_unix::manage_ssh {
@@ -42,7 +45,7 @@ class duo_unix::yum {
 
   package {  $duo_unix::duo_package:
     ensure  => $package_state,
-    require => [ Yumrepo['duosecurity'], Exec['Duo Security GPG Import'] ];
+    require => [ Exec['Duo Security GPG Import'] ];
   }
 
   exec { 'Duo Security GPG Import':


### PR DESCRIPTION
It's useful to be able to skip / disable repo creation, especially when using local mirrors for upstream packages (so deployments and provisioning are not dependent on Internet connectivity at build-time).  This PR adds a `manage_repo` flag (defaulting to `true`) to allow control over the creation and usage of upstream apt / yum repositories.