### PR TITLE
Fix wrong pam file on CentOS 6

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -38,8 +38,8 @@ class duo_unix (
       $gpg_file    = '/etc/pki/rpm-gpg/RPM-GPG-KEY-DUO'
 
       $pam_file = $::operatingsystemrelease ? {
-        /^5/ => '/etc/pam.d/system-auth',
-        /^(6|7|2014)/ => '/etc/pam.d/password-auth'
+        /^(5|6)/ => '/etc/pam.d/system-auth',
+        /^(7|2014)/ => '/etc/pam.d/password-auth'
       }
 
       $pam_module  = $::architecture ? {


### PR DESCRIPTION
When using CentOS 6 the password-auth configuration file is not included.
However using system-auth works.