### PR TITLE
Add manage_pam configuration parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,6 +114,10 @@ for this setting.
 Configures whether or not to allow the module to manage the SSH service/package. 
 The default is *true*.
 
+####`manage_pam [optinal]`
+Configures whether or not to allow the module to manage the system PAM configuration.
+The default is *true*.
+
 ####`pam_unix_control [optional]`
 Configures the PAM control value for pam_duo. The default is *requisite*.
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -20,6 +20,7 @@ class duo_unix (
   $prompts = '3',
   $accept_env_factor = 'no',
   $manage_ssh = true,
+  $manage_pam = true,
   $pam_unix_control = 'requisite',
   $package_version = 'installed',
 ) {

--- a/manifests/pam.pp
+++ b/manifests/pam.pp
@@ -31,31 +31,32 @@ class duo_unix::pam {
     }
   }
 
-  if $::osfamily == 'RedHat' {
-    augeas { 'PAM Configuration':
-      changes => [
-        "set ${aug_pam_path}/2/control ${duo_unix::pam_unix_control}",
-        "ins 100 after ${aug_pam_path}/2",
-        "set ${aug_pam_path}/100/type auth",
-        "set ${aug_pam_path}/100/control sufficient",
-        "set ${aug_pam_path}/100/module ${duo_unix::pam_module}"
-      ],
-      require => Package[$duo_unix::duo_package],
-      onlyif  => "match ${aug_match} size == 0";
-    }
+  if $duo_unix::manage_pam {
+    if $::osfamily == 'RedHat' {
+      augeas { 'PAM Configuration':
+        changes => [
+          "set ${aug_pam_path}/2/control ${duo_unix::pam_unix_control}",
+          "ins 100 after ${aug_pam_path}/2",
+          "set ${aug_pam_path}/100/type auth",
+          "set ${aug_pam_path}/100/control sufficient",
+          "set ${aug_pam_path}/100/module ${duo_unix::pam_module}"
+        ],
+        require => Package[$duo_unix::duo_package],
+        onlyif  => "match ${aug_match} size == 0";
+      }
 
-  } else {
-    augeas { 'PAM Configuration':
-      changes => [
-        "set ${aug_pam_path}/1/control ${duo_unix::pam_unix_control}",
-        "ins 100 after ${aug_pam_path}/1",
-        "set ${aug_pam_path}/100/type auth",
-        "set ${aug_pam_path}/100/control '[success=1 default=ignore]'",
-        "set ${aug_pam_path}/100/module ${duo_unix::pam_module}"
-      ],
-      require => Package[$duo_unix::duo_package],
-      onlyif  => "match ${aug_match} size == 0";
+    } else {
+      augeas { 'PAM Configuration':
+        changes => [
+          "set ${aug_pam_path}/1/control ${duo_unix::pam_unix_control}",
+          "ins 100 after ${aug_pam_path}/1",
+          "set ${aug_pam_path}/100/type auth",
+          "set ${aug_pam_path}/100/control '[success=1 default=ignore]'",
+          "set ${aug_pam_path}/100/module ${duo_unix::pam_module}"
+        ],
+        require => Package[$duo_unix::duo_package],
+        onlyif  => "match ${aug_match} size == 0";
+      }
     }
   }
-
 }


### PR DESCRIPTION
We want to use duo_unix to configure and install duo itself,
but we want to configure the actual pam stack manually.
Setting manage_pam => false prevents the module from
editing password-auth or other pam files.