### PR TITLE
Fix Puppet 4 string comparison (second attempt)

### DIFF
--- a/manifests/yum.pp
+++ b/manifests/yum.pp
@@ -19,7 +19,7 @@ class duo_unix::yum {
     }
     $os = $::operatingsystem
   } elsif ( $::operatingsystem == 'RedHat' and
-            $::operatingsystemmajrelease == 5 ) {
+            versioncmp($::operatingsystemmajrelease,'5') ) {
     $os = 'CentOS'
     $releasever = '$releasever'
   } elsif ( $::operatingsystem == 'OracleLinux' ) {


### PR DESCRIPTION
Puppet 4 types the fact operatingsystemmajrelease as a string but a comparison against the integer 5 will now fail. As a fix, use the versioncmp() function to compare both strings. versioncmp() exists in Puppet 3 but I'm unable to test if this will work.
