### PR TITLE
Use Major Release and not just Release Version in yum

### DIFF
--- a/manifests/yum.pp
+++ b/manifests/yum.pp
@@ -27,7 +27,7 @@ class duo_unix::yum {
     $releasever = '$releasever'
   } else {
     $os = $::operatingsystem
-    $releasever = '$releasever'
+    $releasever = $::operatingsystemmajrelease
   }
 
   yumrepo { 'duosecurity':


### PR DESCRIPTION
The "releasever" default variable contains both major *AND* minor releases, resulting in 404 errors trying to install packages. This update changes that to use JUST the major release. 

For example, under the current scheme, the yum repo URL is built with "7.2" (which does not exist) and not "7" (which does) under CentOS 7.2. This will also follow for RHEL and other RHEL-based systems.